### PR TITLE
added phoneme mapping of ix to the README mapping table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The original TIMIT dataset contains 61 phonemes, we use 61 phonemes for training
 | Original Phoneme(s) | Mapped Phoneme |
 | :------------------  | :-------------------: |
 | iy | iy |
-| ih | ix |
+| ix, ih | ix |
 | eh | eh |
 | ae | ae |
 | ax, ah, ax-h | ax | 


### PR DESCRIPTION
ix was missing in the phoneme mapping table in README. Added ix.